### PR TITLE
specify libraries versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ with open("README.md", mode="r", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    'transformers',
-    'tqdm',
-    'torch>=1.6.0',
-    'numpy',
-    'jsonlines',
-    'sentencepiece',
-    'pytorch_pretrained_bert'
+    'transformers==4.30.2',
+    'tqdm==4.65.0',
+    'torch==1.13.1',
+    'numpy==1.24.2',
+    'jsonlines==3.1.0',
+    'sentencepiece==0.1.99',
+    'pytorch_pretrained_bert==0.6.2'
 ]
 
 setup(


### PR DESCRIPTION
## Changes
I specified the versions of the libraries to be installed in the setup

## Background
I fixed the error caused by the version difference in transformers.

```bash
Traceback (most recent call last):
  File "/usr/src/run_waitress.py", line 9, in <module>
    app = server.create_server()
  File "/usr/src/es_essay_scoring_api/app/server.py", line 13, in create_server
    from .controller import spell_check
  File "/usr/src/es_essay_scoring_api/app/controller/spell_check.py", line 16, in <module>
    spell_checker = SpellChecker()
  File "/usr/src/es_essay_scoring_api/app/models/spell_checker.py", line 13, in __init__
    self.checker.from_pretrained()
  File "/usr/src/es_essay_scoring_api/app/models/neuspell/neuspell/corrector.py", line 140, in from_pretrained
    self._from_pretrained(ckpt_path=None, vocab_path=None, **kwargs)
  File "/usr/src/es_essay_scoring_api/app/models/neuspell/neuspell/corrector.py", line 135, in _from_pretrained
    self.load_model(self.ckpt_path)
  File "/usr/src/es_essay_scoring_api/app/models/neuspell/neuspell/corrector_subwordbert.py", line 29, in load_model
    self.model = load_pretrained(initialized_model, self.ckpt_path, device=self.device)
  File "/usr/src/es_essay_scoring_api/app/models/neuspell/neuspell/seq_modeling/subwordbert.py", line 37, in load_pretrained
    model.load_state_dict(checkpoint_data)
  File "/root/.local/share/virtualenvs/src-NCIGkioc/lib/python3.9/site-packages/torch/nn/modules/module.py", line 2041, in load_state_dict
    raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for SubwordBert:
	Unexpected key(s) in state_dict: "bert_model.embeddings.position_ids".
```
